### PR TITLE
main.cpp is now UNIX-compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ Makefile
 cmake_install.cmake
 install_manifest.txt
 build_win32/
+build/
 dist/
 docs/

--- a/main.cpp
+++ b/main.cpp
@@ -1,8 +1,15 @@
-#include <windows.h>
 #include "parser/include/parser.h"
 #include "engine/include/Whitedrop.h"
 #include <string>
+#if OGRE_PLATFORM == OGRE_PLATFORM_WIN32
+#include <windows.h>
+#endif
+
+#if OGRE_PLATFORM == OGRE_PLATFORM_WIN32
 int WINAPI WinMain ( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd )
+#else 
+int main(int argc, char* argv[])
+#endif
 {
 	Parser::input("../media/maps/basic-map.json");
 	Parser::World world = Parser::load();


### PR DESCRIPTION
windows.h fait partie de l'API Win32 et n'est donc compatible qu'avec Windows. J'ai donc utilisé la structure de base que j'ai trouvée ici: http://www.ogre3d.org/tikiwiki/tiki-index.php?page=Basic+Tutorial+6#The_Initial_Code pour le rendre multiplateformes. 
P.S: tu préfère que j'écrives mes pull request en anglais ou en français ? 
